### PR TITLE
Updated Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,17 +7,18 @@ C_COMPILER=i586-elf-gcc
 ASM_COMPILER=nasm
 LINKER=i586-elf-ld
 
-CFLAGS=-I./src/include -fleading-underscore -O -fstrength-reduce -fomit-frame-pointer -finline-functions -nostdinc -fno-builtin
+CFLAGS=-I./src/include -fleading-underscore -O -ffreestanding
 LDFLAGS=-T./src/link.ld
 ASFLAGS=-felf
 
-SOURCES=src/start.o src/kernel.o src/scrn.o src/gdt.o src/idt.o src/isrs.o src/irq.o src/timer.o src/kb.o src/shell.o src/common.o src/string.o
+SOURCES= $(shell ls src/*.c)
+OBJECTS= $(SOURCES:.c=.o)
 
-all: $(SOURCES) link
+all: $(OBJECTS) link
 clean:
 	-rm ./src/*.o
 link:
-	$(LINKER) $(LDFLAGS) -o bin/kernel.x $(SOURCES)
+	$(LINKER) $(LDFLAGS) -o bin/kernel.x $(OBJECTS)
 .c.o:
 	$(C_COMPILER) $(CFLAGS) -c $< -o $@
 


### PR DESCRIPTION
-ffreestanding is better than -nostdinc because it lets you use standard headers (like stdint or stdbool)
-fstrength-reduce has been useless since gcc 2.4
-finline-functions is a silly thing. It makes the binaries huge and should never have survived this long in the make.

I also changed the way that sources are located so you don't have to add every source file in the src directory (shell trickery)